### PR TITLE
Use NSIndexPath.row because NSIndexPath.item is supported in iOS 6.0 and later.

### DIFF
--- a/iOSPushSample/KiiUserListViewController.m
+++ b/iOSPushSample/KiiUserListViewController.m
@@ -74,9 +74,9 @@
             cell.textLabel.text = [[self tableCellKiiUserContentsArray] objectAtIndex:(NSUInteger) indexPath.row];
             break;
         case 1:
-            if(indexPath.item == 0){
+            if(indexPath.row == 0){
                 cell = [self setDebugSwitch:cell withIndex:(NSUInteger) indexPath.row];
-            } else if (indexPath.item == 1){
+            } else if (indexPath.row == 1){
                 cell = [self setMessageShowSwitch:cell withIndex:(NSUInteger) indexPath.row];
             }
             break;


### PR DESCRIPTION
For http://developer.apple.com/library/ios/#documentation/uikit/reference/NSIndexPath_UIKitAdditions/Reference/Reference.html NSIndexPath.item is supported in iOS 6.0 and later. 
If we want to support iOS 5.0, we must use NSIndexPath.row or Application is crashed when 'KiiUser control' tab is selected.
